### PR TITLE
As Exchange 2010 support PrincipalWantsCopy for MeetingRequestType

### DIFF
--- a/ExchangeWebServices/Source/MS-OXWSMTGS/TestSuite/MS-OXWSMTGS_ExchangeServer2010_SHOULDMAY.deployment.ptfconfig
+++ b/ExchangeWebServices/Source/MS-OXWSMTGS/TestSuite/MS-OXWSMTGS_ExchangeServer2010_SHOULDMAY.deployment.ptfconfig
@@ -106,7 +106,7 @@
     <!--Set R3311Enabled to true to verify that the implementation does support value "calendar:ConflictingMeetingCount" specifies the ConflictingMeetingCount property. Set R3311Enabled to false to disable this requirement.-->
     <Property name="R8852Enabled" value="true" />
     <!--Set R7512Enabled to true to verify that the implementation does support PrincipalWantsCopy which indicates that the meeting request belongs to a principal who has forwarded meeting messages to a delegate. Set R7512Enabled to false to disable this requirement.-->
-    <Property name="R7512Enabled" value="false" />
+    <Property name="R7512Enabled" value="true" />
     <!--Set R911Enabled to true to verify that the implementation does support the TimeZoneType complex type. Set R911Enabled to false to disable this requirement.-->
     <Property name="R911Enabled" value="false" />
   </Properties>


### PR DESCRIPTION
Exchange 2010 support PrincipalWantsCopy for MeetingRequestType as mentioned in TDI10930,

Changed R7512Enabled to true in 2010 should/may config file. R7512 test passed in Exchange 2010.