### PR TITLE
Add R313Enabled in 2010 SHOULD/MAY config file

### DIFF
--- a/ExchangeActiveSync/Source/MS-ASCAL/TestSuite/MS-ASCAL_ExchangeServer2010_SHOULDMAY.deployment.ptfconfig
+++ b/ExchangeActiveSync/Source/MS-ASCAL/TestSuite/MS-ASCAL_ExchangeServer2010_SHOULDMAY.deployment.ptfconfig
@@ -19,5 +19,7 @@
     <Property name="R2242Enabled" value="true"/>
     <!-- Set R52529Enabled to true to verify that implementation does not replace Email element with suitable placeholder text if the value of the Email element is not formatted as specified in [MS-ASDTYPE] section 2.6.2. Set R52529Enabled to false to disable this requirement.-->
     <Property name="R52529Enabled" value="true"/>
+    <!-- Set R313Enabled to true to verify that the MeetingStatus return 5 when the meeting has been canceled and the user was the meeting organizer.-->
+    <Property name="R313Enabled" value="true"/>
   </Properties>
 </TestSite>

--- a/ExchangeActiveSync/Source/MS-ASCMD/TestSuite/S23_Find.cs
+++ b/ExchangeActiveSync/Source/MS-ASCMD/TestSuite/S23_Find.cs
@@ -429,7 +429,7 @@
         /// This test case is used to verify the Find response when the found items have the multiple matched items.
         /// </summary>
         [TestCategory("MSASCMD"), TestMethod()]
-        public void MSASCMD_S23_TC05_Find_NoMatchedItem()
+        public void MSASCMD_S23_TC06_Find_NoMatchedItem()
         {
             Site.Assume.AreEqual<string>("16.1", Common.GetConfigurationPropertyValue("ActiveSyncProtocolVersion", this.Site), "The Find command is only supported when the MS-ASProtocolVersion header is set to 16.1. MS-ASProtocolVersion header value is determined using Common PTFConfig property named ActiveSyncProtocolVersion.");
 


### PR DESCRIPTION
<!-- Set R313Enabled to true to verify that the MeetingStatus return 5 when the meeting has been canceled and the user was the meeting organizer.-->
<Property name="R313Enabled" value="true"/>
in 2010 SHOULD/MAY config file